### PR TITLE
Fix obsidian team considerations

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) 2024 Antonio Sanchez dos Santos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/main.ts
+++ b/main.ts
@@ -12,13 +12,12 @@ export default class ProfMatchIaPlugin extends Plugin {
 	template_folder: string;
 
 	async onload() {
-		console.log("Loading Professional Experience Summary plugin");
 		await this.loadSettings();
 		this.orchestrator = new Orchestrator(this.app, this.settings);
 
 		this.addCommand({
-			id: "generate-summary",
-			name: "Generate Summary",
+			id: "generate-job-experiences",
+			name: "Generate job experiences",
 			callback: async () => {
 				this.orchestrator.summarize();
 			},

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "ia-cv-maker",
-	"name": "IA Curriculum Maker",
+	"id": "ai-cv-maker",
+	"name": "AI Curriculum Maker",
 	"version": "0.0.6",
 	"minAppVersion": "1.5.12",
 	"description": "Effortlessly match professional experiences notes to jobs description using AI.",

--- a/src/plugin-settings.ts
+++ b/src/plugin-settings.ts
@@ -36,12 +36,8 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 
 		containerEl.empty();
 
-		containerEl.createEl("h2", {
-			text: "Professional Experience Summary Settings",
-		});
-
 		new Setting(containerEl)
-			.setName("Job Experience Folder")
+			.setName("Job experience folder")
 			.setDesc("Folder containing your job experiences markdown files (Each job experience should be a Note).")
 			.addText((text) =>
 				text
@@ -54,7 +50,7 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName("Curriculum Templates Folder")
+			.setName("Curriculum templates folder")
 			.setDesc("Folder containing your curriculums templates notes. IMPORTANT: please add to your curriculum tamplate the place holder: '{{{{Job-Experiences}}}}'. You can find a example at ")
 			.addText((text) =>
 				text
@@ -67,7 +63,7 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName("Job Opportunities Folder")
+			.setName("Job opportunities folder")
 			.setDesc("Folder containing the job description notes")
 			.addText((text) =>
 				text
@@ -80,7 +76,7 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 			);
 
 		new Setting(containerEl)
-			.setName("Output Folder")
+			.setName("Output folder")
 			.setDesc("Folder to save the summarized curriculums in a note")
 			.addText((text) =>
 				text
@@ -93,12 +89,10 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 			);
 
 
-		containerEl.createEl("h2", {
-			text: "Open AI Configurations",
-		});
+		new Setting(containerEl).setName("Open AI configurations").setHeading();
 
 		new Setting(containerEl)
-			.setName("OpenAI API Key")
+			.setName("OpenAI API key")
 			.setDesc("Enter your OpenAI API key")
 			.addText((text) =>
 				text
@@ -111,7 +105,7 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 			);
 
 			new Setting(containerEl)
-			.setName("Chat GPT Model")
+			.setName("Chat GPT model")
 			.setDesc("Enter the model that you want to use.")
 			.addText((text) =>
 				text
@@ -124,7 +118,7 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 			);
 
 			new Setting(containerEl)
-			.setName("Prompt to identify the Job Description")
+			.setName("Prompt to identify the job description")
 			.setDesc(
 				"You can customize the prompt used to ChatGPT read the Job Description.\n\nIMPORTANT: please add the placeholder '{{job-description}}'"
 			)
@@ -139,7 +133,7 @@ export class ProfMatchIaSettingTab extends PluginSettingTab {
 			);
 
 			new Setting(containerEl)
-			.setName("Prompt to summiraze one Job Experience")
+			.setName("Prompt to summiraze one job experience")
 			.setDesc(
 				"You can customize the prompt used to summiraze each job experience that will be added in the curriculum.\n\nIMPORTANT: please add the placeholder '{{job-experience}}'"
 			)

--- a/src/prof-match-ia.ts
+++ b/src/prof-match-ia.ts
@@ -25,7 +25,6 @@ export class ProfMatchIa {
 	async getExpiriencesNotesFromFolder(
 		experienceFiles: TFile[]
 	): Promise<ExperienceEntry[]> {
-		console.log("Getting Summaries.");
 		const summaries: ExperienceEntry[] = [];
 		for (const file of experienceFiles) {
 			const content = await this.app.vault.read(file);
@@ -59,8 +58,7 @@ export class ProfMatchIa {
 			jobDescription
 		);
 		await chatGpt.getCompletion(jobDescriptionPrompt);
-		setTimeout(() => {}, 20000); // 20 seconds
-		new Notice("Registered Job Description in the Chat GPT context");
+		new Notice("Registered job description in the chat GPT context");
 
 		// Add Each Job Experience file to a ChatGPT call. It allows 3 calls per minute, so I have to implement a throttle.
 		let summarized = "";
@@ -74,7 +72,7 @@ export class ProfMatchIa {
 			await chatGpt.getCompletion(jobExperiencePrompt).then((result) => {
 				summarized += result + "\n";
 			});
-			new Notice(`Get Job Experience: '${summary.fileName}' summarized.`);
+			new Notice(`Get job experience: '${summary.fileName}' summarized.`);
 		}
 
 		return summarized;
@@ -101,15 +99,6 @@ export class ProfMatchIa {
 			.padStart(2, "0")}`;
 		const outputFileName = `Resume-${dateString}.md`;
 		const outputPath = `${outputFolder}/${outputFileName}`;
-
-		// const summaryContent = summaries
-		// 	.map(
-		// 		(entry) =>
-		// 			`## ${entry.jobtitle} | ${entry.fileName} | ${
-		// 				entry.started
-		// 			} - ${entry.ended || "Present"}\n\n${entry.summary}`
-		// 	)
-		// 	.join("\n\n");
 
 		await this.app.vault.create(outputPath, summaryContent);
 		new Notice(`Created new file: ${outputPath}`);


### PR DESCRIPTION
[Copyright (c) [year] [fullname]](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/LICENSE#L3)
Fill this.

["name": "IA Curriculum Maker",](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/manifest.json#L3)
The README says "AI" but this says "IA", which one is correct.

["authorUrl": "https://www.sancheztoni.com",](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/manifest.json#L8-L9)
This website does not work.

[console.log("Loading Professional Experience Summary plugin");](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/main.ts#L15)
Wrong plugin name.

[name: "Generate Summary",](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/main.ts#L21), [new Notice("Registered Job Description in the Chat GPT context");](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/prof-match-ia.ts#L63), [new Notice(Get Job Experience: '${summary.fileName}' summarized.);](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/prof-match-ia.ts#L77), [.setName("Job Experience Folder")](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L44), [.setName("Curriculum Templates Folder")](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L57), [.setName("Job Opportunities Folder")](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L70), [.setName("Output Folder")](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L83), [.setName("Chat GPT Model")](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L114), [.setName("Prompt to identify the Job Description")](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L127), [.setName("Prompt to summiraze one Job Experience")](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L142)
[Use sentence case in UI](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Use+sentence+case+in+UI)

[console.log("Getting Summaries.");](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/prof-match-ia.ts#L28)
Please avoid unnecessary logging. If you need it for debugging purposes, add a check to only log during development.

[setTimeout(() => {}, 20000); // 20 seconds](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/prof-match-ia.ts#L62)
Why is this necessary?

[containerEl.createEl("h2", {](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L39-L41)
[Don't add a top-level heading in the settings tab, such as "General", "Settings", or the name of your plugin.](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Only+use+headings+under+settings+if+you+have+more+than+one+section.)

[containerEl.createEl("h2", {](https://github.com/ACSancheZ/prof-match-ai/blob/f2c4aaf2880d2896e9c3bba1d9f8c20bb3b49f7c/src/plugin-settings.ts#L96-L98)
For section headings in settings use:

new Setting(containerEl).setName('name here').setHeading();

and [avoid "configurations" in settings headings](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Avoid+%22settings%22+in+settings+headings)